### PR TITLE
Upgrade to rodio 0.8 to enable mp3 support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ documentation = "https://docs.rs/impose/"
 description = "Minimalist audio lib"
 
 [dependencies]
-rodio = "0.7"
+rodio = "0.8"


### PR DESCRIPTION
The library compiled without errors _on my box_ after bumping to rodio 0.8.  Lets see what travis thinks...